### PR TITLE
Allow Agent Studio only in TLS workspace

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -23,7 +23,7 @@ tasks:
   - type: run_session
     name: Pre installation check
     script: startup_scripts/pre_install_check.py
-    short_summary: Check the environment before the Agent studio installation.
+    short_summary: Check the environment before Agent Studio installation.
     kernel: python3
     cpu: 1
     memory: 4

--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -21,6 +21,13 @@ runtimes:
 
 tasks:
   - type: run_session
+    name: Pre installation check
+    script: startup_scripts/pre_install_check.py
+    short_summary: Check the environment before the Agent studio installation.
+    kernel: python3
+    cpu: 1
+    memory: 4
+  - type: run_session
     name: Ensure uv Package Manager
     script: startup_scripts/ensure-uv-package-manager.py
     short_summary: Check for the presence of uv package manager and install it if it is not present.

--- a/startup_scripts/pre_install_check.py
+++ b/startup_scripts/pre_install_check.py
@@ -1,0 +1,23 @@
+from urllib.parse import urlparse
+import sys
+import os
+
+
+def check_for_tls_workspace():
+    try:
+        urlobj = urlparse(os.environ["CDSW_PROJECT_URL"])
+        return urlobj.scheme == "https"
+    except KeyError:
+        print("Environment variable 'CDSW_PROJECT_URL' is not set.")
+    except Exception as e:
+        print(f"Unexpected error while checking URL: {e}")
+        
+    return False
+
+def main():
+    if not check_for_tls_workspace():
+        print(f"Cannot install Agent Studio in a non-TLS workspace")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Agent Studio hardcodes the url scheme as https.
Non-TLS workspace is not a production-ready setup for PVC.
Soon, the non-TLS workspace option will be disabled in PVC provision workflow.
This change adds a pre-install validation for the TLS workspace in Agent Studio 

<img width="1280" alt="Screenshot 2025-05-22 at 1 17 29 PM" src="https://github.com/user-attachments/assets/656cc794-c95b-4e88-908c-db535654ba45" />
<img width="1892" alt="Screenshot 2025-05-22 at 1 21 47 PM" src="https://github.com/user-attachments/assets/5ae85417-19fb-4644-8692-28cb159922ba" />
